### PR TITLE
Newer references

### DIFF
--- a/src/CopperDevs.Windowing.Testing/CopperDevs.Windowing.Testing.csproj
+++ b/src/CopperDevs.Windowing.Testing/CopperDevs.Windowing.Testing.csproj
@@ -14,4 +14,8 @@
         <ProjectReference Include="..\sdl3\CopperDevs.Windowing.SDL3\CopperDevs.Windowing.SDL3.csproj"/>
     </ItemGroup>
 
+    <ItemGroup>
+      <PackageReference Include="CopperDevs.Celesium" Version="1.0.0" />
+    </ItemGroup>
+
 </Project>

--- a/src/CopperDevs.Windowing.Testing/CopperDevs.Windowing.Testing.csproj
+++ b/src/CopperDevs.Windowing.Testing/CopperDevs.Windowing.Testing.csproj
@@ -2,10 +2,10 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <LangVersion>13</LangVersion>
+        <LangVersion>14</LangVersion>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 

--- a/src/CopperDevs.Windowing.Testing/CopperDevs.Windowing.Testing.csproj
+++ b/src/CopperDevs.Windowing.Testing/CopperDevs.Windowing.Testing.csproj
@@ -15,7 +15,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CopperDevs.Celesium" Version="1.0.0" />
+      <PackageReference Include="CopperDevs.Celesium" Version="1.0.1" />
     </ItemGroup>
 
 </Project>

--- a/src/CopperDevs.Windowing/BaseWindow.cs
+++ b/src/CopperDevs.Windowing/BaseWindow.cs
@@ -1,5 +1,5 @@
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-using CopperDevs.Core.Utility;
+using CopperDevs.Celesium;
 using CopperDevs.Windowing.Data;
 
 namespace CopperDevs.Windowing;

--- a/src/CopperDevs.Windowing/CopperDevs.Windowing.csproj
+++ b/src/CopperDevs.Windowing/CopperDevs.Windowing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -16,7 +16,7 @@
         <Company>copperdevs</Company>
         <PackageLicenseFile>License.txt</PackageLicenseFile>
         <PackageReadmeFile>ReadMe.md</PackageReadmeFile>
-        <LangVersion>13</LangVersion>
+        <LangVersion>14</LangVersion>
         <AssemblyVersion>1.2.1</AssemblyVersion>
         <FileVersion>1.2.1</FileVersion>
         <Version>1.2.1</Version>

--- a/src/CopperDevs.Windowing/CopperDevs.Windowing.csproj
+++ b/src/CopperDevs.Windowing/CopperDevs.Windowing.csproj
@@ -31,7 +31,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="CopperDevs.Celesium" Version="1.0.0" />
+        <PackageReference Include="CopperDevs.Celesium" Version="1.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/CopperDevs.Windowing/CopperDevs.Windowing.csproj
+++ b/src/CopperDevs.Windowing/CopperDevs.Windowing.csproj
@@ -31,8 +31,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="CopperDevs.Core" Version="1.1.13" />
-        <PackageReference Include="CopperDevs.Logger" Version="1.0.1"/>
+        <PackageReference Include="CopperDevs.Celesium" Version="1.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/CopperDevs.Windowing/Data/Input.cs
+++ b/src/CopperDevs.Windowing/Data/Input.cs
@@ -1,5 +1,5 @@
 using System.Numerics;
-using CopperDevs.Logger;
+using CopperDevs.Celesium;
 
 namespace CopperDevs.Windowing.Data;
 

--- a/src/CopperDevs.Windowing/Data/Input.cs
+++ b/src/CopperDevs.Windowing/Data/Input.cs
@@ -22,7 +22,7 @@ public static class Input
         if (input is not null)
             return true;
 
-        Log.Warning("Input is not setup, attempting to setup now");
+        Log.Warn("Input is not setup, attempting to setup now");
         window.SetupInput();
 
         return input is not null;

--- a/src/CopperDevs.Windowing/Data/WindowOptions.cs
+++ b/src/CopperDevs.Windowing/Data/WindowOptions.cs
@@ -1,5 +1,4 @@
-using CopperDevs.Core.Data;
-using CopperDevs.Core.Utility;
+using CopperDevs.Celesium;
 
 namespace CopperDevs.Windowing.Data;
 
@@ -18,11 +17,14 @@ public record WindowOptions
     /// Starting title of the window on creation
     /// </summary>
     public string Title = "Untitled Window";
-    
+
     /// <summary>
     /// Delay in milliseconds between each frame render
     /// </summary>
-    public Optional<int> FrameRenderDelay = new(10);
+    /// <remarks>
+    /// Set to 0 (or any value below) to disable 
+    /// </remarks>
+    public int FrameRenderDelay = 10;
 
     /// <summary>
     /// Default settings

--- a/src/CopperDevs.Windowing/WindowHandler.cs
+++ b/src/CopperDevs.Windowing/WindowHandler.cs
@@ -50,8 +50,8 @@ public partial class Window
         OnUpdate?.Invoke();
         OnRender?.Invoke();
 
-        if (Options.FrameRenderDelay.Enabled)
-            Thread.Sleep(Options.FrameRenderDelay.Value);
+        if (Options.FrameRenderDelay > 0)
+            Thread.Sleep(Options.FrameRenderDelay);
 
         StopWindowUpdate();
     }

--- a/src/CopperDevs.Windowing/WindowInfo.cs
+++ b/src/CopperDevs.Windowing/WindowInfo.cs
@@ -1,4 +1,4 @@
-using CopperDevs.Core.Data;
+using CopperDevs.Celesium;
 using CopperDevs.Windowing.Data;
 
 namespace CopperDevs.Windowing;
@@ -15,7 +15,7 @@ public partial class Window
         get => GetWindowPosition();
         set => SetWindowPosition(value);
     }
-    
+
     /// <summary>
     /// Current size of the window
     /// </summary>
@@ -99,7 +99,7 @@ public partial class Window
     /// Is the window currently being hovered by the mouse
     /// </summary>
     public bool Hovered => GetHovered();
-    
+
     /// <summary>
     /// Maximize the window 
     /// </summary>
@@ -109,11 +109,11 @@ public partial class Window
     /// Minimize the window
     /// </summary>
     public void Minimize() => SetMinimize();
-    
+
     /// <summary>
     /// Get the UI theme for the system
     /// </summary>
-    public SystemTheme SystemTheme => GetSystemTheme();  
+    public SystemTheme SystemTheme => GetSystemTheme();
 
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     // time
@@ -159,7 +159,7 @@ public partial class Window
     // focus
     protected abstract bool GetFocused();
     protected abstract bool GetHovered();
-    
+
     // theme
     protected abstract SystemTheme GetSystemTheme();
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member

--- a/src/sdl3/CopperDevs.Windowing.SDL3.Example/CopperDevs.Windowing.SDL3.Example.csproj
+++ b/src/sdl3/CopperDevs.Windowing.SDL3.Example/CopperDevs.Windowing.SDL3.Example.csproj
@@ -2,9 +2,10 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <LangVersion>14</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/sdl3/CopperDevs.Windowing.SDL3.Example/CopperDevs.Windowing.SDL3.Example.csproj
+++ b/src/sdl3/CopperDevs.Windowing.SDL3.Example/CopperDevs.Windowing.SDL3.Example.csproj
@@ -14,7 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CopperDevs.Celesium" Version="1.0.0" />
+      <PackageReference Include="CopperDevs.Celesium" Version="1.0.1" />
     </ItemGroup>
     
 </Project>

--- a/src/sdl3/CopperDevs.Windowing.SDL3.Example/CopperDevs.Windowing.SDL3.Example.csproj
+++ b/src/sdl3/CopperDevs.Windowing.SDL3.Example/CopperDevs.Windowing.SDL3.Example.csproj
@@ -12,5 +12,9 @@
       <ProjectReference Include="..\..\CopperDevs.Windowing\CopperDevs.Windowing.csproj" />
       <ProjectReference Include="..\CopperDevs.Windowing.SDL3\CopperDevs.Windowing.SDL3.csproj" />
     </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="CopperDevs.Celesium" Version="1.0.0" />
+    </ItemGroup>
     
 </Project>

--- a/src/sdl3/CopperDevs.Windowing.SDL3.Example/Program.cs
+++ b/src/sdl3/CopperDevs.Windowing.SDL3.Example/Program.cs
@@ -1,6 +1,5 @@
 ﻿using System.Numerics;
-using CopperDevs.Core.Data;
-using CopperDevs.Core.Utility;
+using CopperDevs.Celesium;
 using CopperDevs.Windowing.Data;
 using CopperDevs.Windowing.SDL3.Data;
 
@@ -62,7 +61,7 @@ public static class Program
         if (Input.IsKeyPressed(InputKey.Right))
             scale += ArrowChanger;
 
-        scale = MathUtil.Clamp(scale, ScaleRange.X, ScaleRange.Y);
+        scale = Math.Clamp(scale, ScaleRange.X, ScaleRange.Y);
 
         renderer.Scale = Vector2.One * scale;
     }

--- a/src/sdl3/CopperDevs.Windowing.SDL3.Generator/CopperDevs.Windowing.SDL3.Generator.csproj
+++ b/src/sdl3/CopperDevs.Windowing.SDL3.Generator/CopperDevs.Windowing.SDL3.Generator.csproj
@@ -10,8 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="CopperDevs.Core" Version="1.1.13" />
-        <PackageReference Include="CopperDevs.Logger" Version="1.0.1" />
+        <PackageReference Include="CopperDevs.Celesium" Version="1.0.0" />
         <PackageReference Include="ppy.SDL3-CS" Version="2025.220.0" />
     </ItemGroup>
 

--- a/src/sdl3/CopperDevs.Windowing.SDL3.Generator/CopperDevs.Windowing.SDL3.Generator.csproj
+++ b/src/sdl3/CopperDevs.Windowing.SDL3.Generator/CopperDevs.Windowing.SDL3.Generator.csproj
@@ -2,10 +2,11 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <LangVersion>14</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/sdl3/CopperDevs.Windowing.SDL3.Generator/CopperDevs.Windowing.SDL3.Generator.csproj
+++ b/src/sdl3/CopperDevs.Windowing.SDL3.Generator/CopperDevs.Windowing.SDL3.Generator.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="CopperDevs.Celesium" Version="1.0.0" />
+        <PackageReference Include="CopperDevs.Celesium" Version="1.0.1" />
         <PackageReference Include="ppy.SDL3-CS" Version="2025.220.0" />
     </ItemGroup>
 

--- a/src/sdl3/CopperDevs.Windowing.SDL3.Generator/Program.cs
+++ b/src/sdl3/CopperDevs.Windowing.SDL3.Generator/Program.cs
@@ -1,5 +1,5 @@
 ﻿using System.Reflection;
-using CopperDevs.Logger;
+using CopperDevs.Celesium;
 using SDL;
 
 namespace CopperDevs.Windowing.SDL3.Generator;
@@ -8,7 +8,7 @@ internal static class HotReloadCallbackReceiver
 {
     public static void UpdateApplication(Type[] updatedTypes)
     {
-        Log.Warning("Program Hot Reloaded");
+        Log.Warn("Program Hot Reloaded");
 
         Program.CreateFiles();
         Program.GenerateMethods();

--- a/src/sdl3/CopperDevs.Windowing.SDL3/CopperDevs.Windowing.SDL3.csproj
+++ b/src/sdl3/CopperDevs.Windowing.SDL3/CopperDevs.Windowing.SDL3.csproj
@@ -32,6 +32,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="CopperDevs.Celesium" Version="1.0.0" />
         <PackageReference Include="ppy.SDL3-CS" Version="2025.220.0" />
     </ItemGroup>
 

--- a/src/sdl3/CopperDevs.Windowing.SDL3/CopperDevs.Windowing.SDL3.csproj
+++ b/src/sdl3/CopperDevs.Windowing.SDL3/CopperDevs.Windowing.SDL3.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -17,7 +17,7 @@
         <Company>copperdevs</Company>
         <PackageLicenseFile>License.txt</PackageLicenseFile>
         <PackageReadmeFile>ReadMe.md</PackageReadmeFile>
-        <LangVersion>13</LangVersion>
+        <LangVersion>14</LangVersion>
         <AssemblyVersion>1.3.1</AssemblyVersion>
         <FileVersion>1.3.1</FileVersion>
         <Version>1.3.1</Version>

--- a/src/sdl3/CopperDevs.Windowing.SDL3/CopperDevs.Windowing.SDL3.csproj
+++ b/src/sdl3/CopperDevs.Windowing.SDL3/CopperDevs.Windowing.SDL3.csproj
@@ -32,7 +32,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="CopperDevs.Celesium" Version="1.0.0" />
+        <PackageReference Include="CopperDevs.Celesium" Version="1.0.1" />
         <PackageReference Include="ppy.SDL3-CS" Version="2025.220.0" />
     </ItemGroup>
 

--- a/src/sdl3/CopperDevs.Windowing.SDL3/ManagedSDLWindow.cs
+++ b/src/sdl3/CopperDevs.Windowing.SDL3/ManagedSDLWindow.cs
@@ -1,5 +1,4 @@
-using CopperDevs.Core.Data;
-using CopperDevs.Core.Utility;
+using CopperDevs.Celesium;
 using CopperDevs.Windowing.Data;
 using CopperDevs.Windowing.SDL3.Data;
 

--- a/src/sdl3/CopperDevs.Windowing.SDL3/SDL3Window.cs
+++ b/src/sdl3/CopperDevs.Windowing.SDL3/SDL3Window.cs
@@ -1,6 +1,6 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using CopperDevs.Core.Data;
+using CopperDevs.Celesium;
 using CopperDevs.Windowing.Data;
 using CopperDevs.Windowing.SDL3.Data;
 

--- a/src/sdl3/CopperDevs.Windowing.SDL3/SDLGPU.cs
+++ b/src/sdl3/CopperDevs.Windowing.SDL3/SDLGPU.cs
@@ -1,5 +1,4 @@
-using CopperDevs.Core.Utility;
-using CopperDevs.Logger;
+using CopperDevs.Celesium;
 using CopperDevs.Windowing.SDL3.Data;
 
 namespace CopperDevs.Windowing.SDL3;

--- a/src/sdl3/CopperDevs.Windowing.SDL3/SDLInput.cs
+++ b/src/sdl3/CopperDevs.Windowing.SDL3/SDLInput.cs
@@ -1,5 +1,5 @@
 using System.Numerics;
-using CopperDevs.Logger;
+using CopperDevs.Celesium;
 using CopperDevs.Windowing.Data;
 using CopperDevs.Windowing.SDL3.Data;
 

--- a/src/sdl3/CopperDevs.Windowing.SDL3/SDLRenderer.cs
+++ b/src/sdl3/CopperDevs.Windowing.SDL3/SDLRenderer.cs
@@ -1,6 +1,5 @@
 using System.Numerics;
-using CopperDevs.Core.Utility;
-using CopperDevs.Logger;
+using CopperDevs.Celesium;
 using CopperDevs.Windowing.Data;
 using CopperDevs.Windowing.SDL3.Data;
 

--- a/src/sdl3/CopperDevs.Windowing.SDL3/Wrapper/Layering.cs
+++ b/src/sdl3/CopperDevs.Windowing.SDL3/Wrapper/Layering.cs
@@ -1,5 +1,5 @@
 using System.Numerics;
-using CopperDevs.Core.Data;
+using CopperDevs.Celesium;
 using CopperDevs.Windowing.Data;
 using CopperDevs.Windowing.SDL3.Data;
 


### PR DESCRIPTION
- Moved from net8 to net10
- Moved from C# 13 to C# 14
- Dropped [CopperDevs.Core](https://github.com/copperdevs/CopperDevs.Core) (and by extension [CopperDevs.Logger](https://github.com/copperdevs/CopperDevs.Core/tree/master/src/logger/CopperDevs.Logger)) in favor of [Celesium](https://github.com/copperdevs/celesium)